### PR TITLE
Fix nullreference in decoding EncryptionResponsePaket

### DIFF
--- a/MCSharp/Pakets/Server/Login/EncryptionResponsePaket.cs
+++ b/MCSharp/Pakets/Server/Login/EncryptionResponsePaket.cs
@@ -12,9 +12,9 @@ namespace MCSharp.Pakets.Server.Login
         public void Decode(MinecraftStream minecraftStream)
         {
             SharedKeyLenght = minecraftStream.ReadVarInt();
-            minecraftStream.Read(SharedKey, SharedKeyLenght);
+            SharedKey = minecraftStream.Read(SharedKeyLenght);
             VerifyTokenLenght = minecraftStream.ReadVarInt();
-            minecraftStream.Read(VerifyToken, VerifyTokenLenght);
+            VerifyToken = minecraftStream.Read(VerifyTokenLenght);
         }
 
         public void Encode(MinecraftStream minecraftStream)


### PR DESCRIPTION
The decoding of the EncryptionResponsePaket throws a NullReferenceException with the current implementarion.